### PR TITLE
Add button to create new filters, fix "Not intuitive how to add filter in advanced search"

### DIFF
--- a/projects/components/src/lib/advanced-search/advanced-search.html
+++ b/projects/components/src/lib/advanced-search/advanced-search.html
@@ -41,10 +41,9 @@
   </div>
 </div>
 
-<div>
+<div class="new-filter-container">
   <button mat-button [mat-menu-trigger-for]="filterTypesMenu" type="button"
-          *ngIf="filterOptions.length" matTooltip="Add filter"
-          class="new-filter">
+          *ngIf="filterOptions.length" matTooltip="Add filter" class="new-filter">
     Add filter
   </button>
 </div>

--- a/projects/components/src/lib/advanced-search/advanced-search.html
+++ b/projects/components/src/lib/advanced-search/advanced-search.html
@@ -1,10 +1,5 @@
 <div class="search-bar">
   <input [formControl]="searchFormControl" placeholder="Search" class="search">
-  <button mat-icon-button [mat-menu-trigger-for]="filterTypesMenu" type="button"
-          *ngIf="filterOptions.length" matTooltip="Add filter"
-          class="new-filter">
-    <mat-icon> filter_list </mat-icon>
-  </button>
 </div>
 
 <div class="filter-container" [@expand]="expandState"
@@ -44,6 +39,14 @@
       </button>
     </ng-container>
   </div>
+</div>
+
+<div>
+  <button mat-button [mat-menu-trigger-for]="filterTypesMenu" type="button"
+          *ngIf="filterOptions.length" matTooltip="Add filter"
+          class="new-filter">
+    Add filter
+  </button>
 </div>
 
 <!-- Filter Types Menu -->

--- a/projects/components/src/lib/advanced-search/advanced-search.scss
+++ b/projects/components/src/lib/advanced-search/advanced-search.scss
@@ -3,17 +3,14 @@
 :host {
   display: flex;
   flex-direction: column;
+  overflow: auto;
 }
 
 .search-bar {
   display: flex;
   align-items: center;
   flex: 1;
-
-  button.new-filter {
-    height: 48px;
-    width: 48px;
-  }
+  padding: 10px 20px 10px 0;
 }
 
 input {
@@ -57,4 +54,11 @@ input {
 
 .menu-title {
   @include menu-title();
+}
+
+.new-filter {
+  float:  right;
+  margin-bottom: 10px;
+  margin-right: 8px;
+  font-size: 12px;
 }

--- a/projects/components/src/lib/advanced-search/advanced-search.scss
+++ b/projects/components/src/lib/advanced-search/advanced-search.scss
@@ -3,14 +3,14 @@
 :host {
   display: flex;
   flex-direction: column;
-  overflow: auto;
 }
 
 .search-bar {
   display: flex;
   align-items: center;
   flex: 1;
-  padding: 10px 20px 10px 0;
+  padding: 8px 16px 8px 0;
+  height: 48px;
 }
 
 input {
@@ -56,9 +56,13 @@ input {
   @include menu-title();
 }
 
-.new-filter {
-  float:  right;
-  margin-bottom: 10px;
+.new-filter-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
   margin-right: 8px;
+}
+
+.new-filter {
   font-size: 12px;
 }

--- a/projects/components/src/lib/form/filter-state-option/filter-state-option.scss
+++ b/projects/components/src/lib/form/filter-state-option/filter-state-option.scss
@@ -1,5 +1,5 @@
 .results-count {
-  margin-top: 8px;
+  margin-top: -38px;
 }
 
 .filter-state-label {


### PR DESCRIPTION
This change addresses:
https://github.com/crafted/crafted/issues/51: Not intuitive how to add filter in advanced search

This change includes:
- Removing the existing filter button on the Queries and New Dashboard pages
- Adding a different button with "Add filter" instead of an icon
- Styling changes for the button and other elements affected by the button change

This change should:
- Make it more intuitive for users to add filters to a search